### PR TITLE
Feature/fsm improv5

### DIFF
--- a/include/QuarkTS.h
+++ b/include/QuarkTS.h
@@ -1,13 +1,13 @@
 /*!
  * @file QuarkTS.h
  * @author J. Camilo Gomez C.
- * @version 2.03
+ * @version 2.04
  * @note This file is part of the QuarkTS distribution.
  * @brief Global inclusion header 
  **/
 
 /*
-QuarkTS V7.0.4- An open-source OS for small embedded applications.
+QuarkTS V7.1.1- An open-source OS for small embedded applications.
 MIT License
 C99 and MISRAC 2012 Compliant    
 
@@ -98,7 +98,7 @@ Read the API reference here ; https://kmilo17pet.github.io/QuarkTS/
 #ifndef QuarkTS_H
     #define	QuarkTS_H
 
-    #define QUARKTS_VERSION         "7.0.4"
+    #define QUARKTS_VERSION         "7.1.1"
     #define QUARKTS_CAPTION         "QuarkTS OS " QUARKTS_VERSION
 
     #include "qtypes.h"

--- a/include/qfsm.h
+++ b/include/qfsm.h
@@ -1,7 +1,7 @@
 /*!
  * @file qfsm.h
  * @author J. Camilo Gomez C.
- * @version 5.27
+ * @version 5.28
  * @note This file is part of the QuarkTS distribution.
  * @brief  API interface of the Finite State Machine (FSM) module.
  **/


### PR DESCRIPTION
FSM Module improvement : Timeouts and Transitions now uses the state as container instead of the state-machine object. This improves performance and memory usage.
- Added qStateMachine_Set_StateTransitions
- Added qStateMachine_Set_StateTimeouts
- Removed qStateMachine_InstallTransitionTable
- Changed qStateMachine_InstallTimeoutSpec
- Changed  qSM_TimeoutStateDefinition_t and qSM_Transition_t
- Other internal changes.